### PR TITLE
[RFC] Add Function.bind, Array.map, and Array.filter polyfills for legacy browsers

### DIFF
--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -11,6 +11,91 @@
     }
 }(this, function () {
     'use strict';
+
+    // ES5 Polyfills
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+    if (!Function.prototype.bind) {
+        Function.prototype.bind = function (oThis) {
+            if (typeof this !== 'function') {
+                throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+            }
+
+            var aArgs = Array.prototype.slice.call(arguments, 1);
+            var fToBind = this;
+            var noOp = function () {
+            };
+            var fBound = function () {
+                return fToBind.apply(this instanceof noOp && oThis ? this : oThis,
+                    aArgs.concat(Array.prototype.slice.call(arguments)));
+            };
+
+            noOp.prototype = this.prototype;
+            fBound.prototype = new noOp();
+
+            return fBound;
+        };
+    }
+
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
+    if (!Array.prototype.map) {
+        Array.prototype.map = function(callback, thisArg) {
+            if (this === void 0 || this === null) {
+                throw new TypeError("this is null or not defined");
+            }
+            var O = Object(this);
+            var len = O.length >>> 0;
+            if (typeof callback !== "function") {
+                throw new TypeError(callback + " is not a function");
+            }
+            if (arguments.length > 1) {
+                var T = thisArg;
+            }
+
+            var A = new Array(len);
+            var k = 0;
+
+            while (k < len) {
+                var kValue, mappedValue;
+                if (k in O) {
+                    kValue = O[k];
+                    mappedValue = callback.call(T, kValue, k, O);
+                    A[k] = mappedValue;
+                }
+                k++;
+            }
+
+            return A;
+        };
+    }
+
+    // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
+    if (!Array.prototype.filter) {
+        Array.prototype.filter = function(callback/*, thisArg*/) {
+            if (this === void 0 || this === null) {
+                throw new TypeError("this is null or not defined");
+            }
+
+            var t = Object(this);
+            var len = t.length >>> 0;
+            if (typeof callback !== "function") {
+                throw new TypeError(callback + " is not a function");
+            }
+
+            var res = [];
+            var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+            for (var i = 0; i < len; i++) {
+                if (i in t) {
+                    var val = t[i];
+                    if (callback.call(thisArg, val, i, t)) {
+                        res.push(val);
+                    }
+                }
+            }
+
+            return res;
+        };
+    }
+
     return function ErrorStackParser() {
         this.firefoxSafariStackEntryRegExp = /\S+\:\d+/;
         this.chromeIEStackEntryRegExp = /\s+at /;
@@ -71,7 +156,7 @@
 
         this.parseOpera = function parseOpera(e) {
             if (!e.stacktrace || (e.message.indexOf('\n') > -1 &&
-                    e.message.split('\n').length > e.stacktrace.split('\n').length)) {
+                e.message.split('\n').length > e.stacktrace.split('\n').length)) {
                 return this.parseOpera9(e);
             } else if (!e.stack) {
                 return this.parseOpera10a(e);


### PR DESCRIPTION
Add ES5 polyfills inline instead of depending on a shim library. 
