### PR TITLE
Represent anonymous functions consistently

### DIFF
--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -15,6 +15,7 @@
 
     var FIREFOX_SAFARI_STACK_REGEXP = /(^|@)\S+\:\d+/;
     var CHROME_IE_STACK_REGEXP = /\s+at .*(\S+\:\d+|\(native\))/;
+    var ANONYMOUS_FUNCTION_NAME = 'Anonymous function';
 
     return {
         /**
@@ -62,11 +63,11 @@
             }, this).map(function (line) {
                 var tokens = line.replace(/^\s+/, '').split(/\s+/).slice(1);
                 var locationParts = this.extractLocation(tokens.pop());
-                var functionName = (!tokens[0]) ? undefined : tokens[0];
+                var functionName = (!tokens[0]) ? ANONYMOUS_FUNCTION_NAME : tokens[0];
 
                 // Special case for IE's 'Anonymous function'
                 if(tokens[0] === 'Anonymous' && tokens[1] === 'function') {
-                    functionName = tokens.slice(0,2).join(' ');
+                    functionName = ANONYMOUS_FUNCTION_NAME;
                 }
 
                 return new StackFrame(functionName, undefined, locationParts[0], locationParts[1], locationParts[2], line);
@@ -79,7 +80,7 @@
             }, this).map(function (line) {
                 var tokens = line.split('@');
                 var locationParts = this.extractLocation(tokens.pop());
-                var functionName = tokens.shift() || undefined;
+                var functionName = tokens.shift() || ANONYMOUS_FUNCTION_NAME;
                 return new StackFrame(functionName, undefined, locationParts[0], locationParts[1], locationParts[2], line);
             }, this);
         },
@@ -118,7 +119,8 @@
             for (var i = 0, len = lines.length; i < len; i += 2) {
                 var match = lineRE.exec(lines[i]);
                 if (match) {
-                    result.push(new StackFrame(match[3] || undefined, undefined, match[2], match[1], undefined, lines[i]));
+                    var functionName = match[3] || ANONYMOUS_FUNCTION_NAME;
+                    result.push(new StackFrame(functionName, undefined, match[2], match[1], undefined, lines[i]));
                 }
             }
 
@@ -136,7 +138,7 @@
                 var functionCall = (tokens.shift() || '');
                 var functionName = functionCall
                         .replace(/<anonymous function(: (\w+))?>/, '$2')
-                        .replace(/\([^\)]*\)/g, '') || undefined;
+                        .replace(/\([^\)]*\)/g, '') || ANONYMOUS_FUNCTION_NAME;
                 var argsRaw;
                 if (functionCall.match(/\(([^\)]*)\)/)) {
                     argsRaw = functionCall.replace(/^[^\(]+\(([^\)]*)\)$/, '$1');

--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -62,7 +62,13 @@
             }, this).map(function (line) {
                 var tokens = line.replace(/^\s+/, '').split(/\s+/).slice(1);
                 var locationParts = this.extractLocation(tokens.pop());
-                var functionName = (!tokens[0] || tokens[0] === 'Anonymous') ? undefined : tokens[0];
+                var functionName = (!tokens[0]) ? undefined : tokens[0];
+
+                // Special case for IE's 'Anonymous function'
+                if(tokens[0] === 'Anonymous' && tokens[1] === 'function') {
+                    functionName = tokens.slice(0,2).join(' ');
+                }
+
                 return new StackFrame(functionName, undefined, locationParts[0], locationParts[1], locationParts[2], line);
             }, this);
         },

--- a/spec/error-stack-parser-spec.js
+++ b/spec/error-stack-parser-spec.js
@@ -70,7 +70,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.IE_10);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 48, 13]);
+            expect(stackFrames[0]).toMatchStackFrame(['Anonymous function', undefined, 'http://path/to/file.js', 48, 13]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 46, 9]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 82, 1]);
         });
@@ -79,7 +79,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.IE_11);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 47, 21]);
+            expect(stackFrames[0]).toMatchStackFrame(['Anonymous function', undefined, 'http://path/to/file.js', 47, 21]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 45, 13]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 108, 1]);
         });

--- a/spec/error-stack-parser-spec.js
+++ b/spec/error-stack-parser-spec.js
@@ -1,5 +1,7 @@
 /* global StackFrame: false, ErrorStackParser: false, CapturedExceptions: false */
 describe('ErrorStackParser', function () {
+    var ANONYMOUS_FUNCTION_NAME = 'Anonymous function';
+
     describe('#parse', function () {
         var unit = ErrorStackParser;
         it('should not parse IE 9 Error', function () {
@@ -12,7 +14,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.SAFARI_6);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 48]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 48]);
             expect(stackFrames[1]).toMatchStackFrame(['dumpException3', undefined, 'http://path/to/file.js', 52]);
             expect(stackFrames[2]).toMatchStackFrame(['onclick', undefined, 'http://path/to/file.js', 82]);
         });
@@ -21,7 +23,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.SAFARI_7);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 48, 22]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 48, 22]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 52, 15]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 108, 107]);
         });
@@ -30,7 +32,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.SAFARI_8);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 47, 22]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 47, 22]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 52, 15]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 108, 23]);
         });
@@ -50,7 +52,7 @@ describe('ErrorStackParser', function () {
             expect(stackFrames[0]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 13, 17]);
             expect(stackFrames[1]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 16, 5]);
             expect(stackFrames[2]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 20, 5]);
-            expect(stackFrames[3]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 24, 4]);
+            expect(stackFrames[3]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 24, 4]);
         });
 
         it('should parse V8 entries with no location', function () {
@@ -70,7 +72,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.IE_10);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame(['Anonymous function', undefined, 'http://path/to/file.js', 48, 13]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 48, 13]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 46, 9]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 82, 1]);
         });
@@ -79,7 +81,7 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.IE_11);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame(['Anonymous function', undefined, 'http://path/to/file.js', 47, 21]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 47, 21]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 45, 13]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 108, 1]);
         });
@@ -97,13 +99,13 @@ describe('ErrorStackParser', function () {
             var stackFrames = unit.parse(CapturedExceptions.OPERA_10);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(7);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 42]);
-            expect(stackFrames[1]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 27]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 42]);
+            expect(stackFrames[1]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 27]);
             expect(stackFrames[2]).toMatchStackFrame(['printStackTrace', undefined, 'http://path/to/file.js', 18]);
             expect(stackFrames[3]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 4]);
             expect(stackFrames[4]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 7]);
             expect(stackFrames[5]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 11]);
-            expect(stackFrames[6]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 15]);
+            expect(stackFrames[6]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 15]);
         });
 
         it('should parse Opera 11 Error messages', function () {
@@ -113,14 +115,14 @@ describe('ErrorStackParser', function () {
             expect(stackFrames[0]).toMatchStackFrame(['run', undefined, 'http://path/to/file.js', 27]);
             expect(stackFrames[1]).toMatchStackFrame(['bar', undefined, 'http://domain.com:1234/path/to/file.js', 18]);
             expect(stackFrames[2]).toMatchStackFrame(['foo', undefined, 'http://domain.com:1234/path/to/file.js', 11]);
-            expect(stackFrames[3]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 15]);
+            expect(stackFrames[3]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 15]);
         });
 
         it('should parse Opera 25 Error stacks', function () {
             var stackFrames = unit.parse(CapturedExceptions.OPERA_25);
             expect(stackFrames).toBeTruthy();
             expect(stackFrames.length).toBe(3);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 47, 22]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 47, 22]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 52, 15]);
             expect(stackFrames[2]).toMatchStackFrame(['bar', undefined, 'http://path/to/file.js', 108, 168]);
         });
@@ -133,7 +135,7 @@ describe('ErrorStackParser', function () {
             });
 
             expect(stackFrames.length).toBe(2);
-            expect(stackFrames[0]).toMatchStackFrame([undefined, undefined, 'http://path/to/file.js', 47, 22]);
+            expect(stackFrames[0]).toMatchStackFrame([ANONYMOUS_FUNCTION_NAME, undefined, 'http://path/to/file.js', 47, 22]);
             expect(stackFrames[1]).toMatchStackFrame(['foo', undefined, 'http://path/to/file.js', 52, 15]);
         });
     });


### PR DESCRIPTION
RFC: Related to #21 

This should disambiguate "anonymous" functions from un-parseable function names.