### PR TITLE
Fully parse function names with @ in Error.stack

### DIFF
--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -119,7 +119,7 @@
                 } else {
                     var tokens = line.split('@');
                     var locationParts = this.extractLocation(tokens.pop());
-                    var functionName = tokens.shift() || undefined;
+                    var functionName = tokens.join('@') || undefined;
                     return new StackFrame(functionName, undefined, locationParts[0], locationParts[1], locationParts[2], line);
                 }
             }, this);

--- a/spec/error-stack-parser-spec.js
+++ b/spec/error-stack-parser-spec.js
@@ -65,6 +65,14 @@ describe('ErrorStackParser', function () {
             expect(stackFrames[4]).toMatchStackFrame([undefined, undefined, 'http://localhost:8080/file.js', 33, 9]);
         });
 
+        it('should parse function names containing @ in Firefox 43 Error.stack', function () {
+            var stackFrames = unit.parse(CapturedExceptions.FIREFOX_43_FUNCTION_NAME_WITH_AT_SIGN);
+            expect(stackFrames).toBeTruthy();
+            expect(stackFrames.length).toBe(2);
+            expect(stackFrames[0]).toMatchStackFrame(['obj["@fn"]', undefined, 'Scratchpad/1', 10, 29]);
+            expect(stackFrames[1]).toMatchStackFrame([undefined, undefined, 'Scratchpad/1', 11, 1]);
+        });
+
         it('should parse V8 Error.stack', function () {
             var stackFrames = unit.parse(CapturedExceptions.CHROME_15);
             expect(stackFrames).toBeTruthy();

--- a/spec/fixtures/captured-errors.js
+++ b/spec/fixtures/captured-errors.js
@@ -253,6 +253,17 @@ CapturedExceptions.FIREFOX_43_NESTED_EVAL = {
     "@http://localhost:8080/file.js:33:9"
 };
 
+CapturedExceptions.FIREFOX_43_FUNCTION_NAME_WITH_AT_SIGN = {
+    message: "Dummy error",
+    name: "Error",
+    stack: 'obj["@fn"]@Scratchpad/1:10:29\n' +
+    "@Scratchpad/1:11:1\n" +
+    "",
+    fileName: "Scratchpad/1",
+    lineNumber: 10,
+    columnNumber: 29
+};
+
 CapturedExceptions.SAFARI_6 = {
     message: "'null' is not an object (evaluating 'x.undef')",
     stack: "@http://path/to/file.js:48\n" +


### PR DESCRIPTION
Function name in `Error.stack` can contain `@` when function is defined as an object property:
```js
const obj = { '@fn'() { throw new Error(); } };
obj['@fn']();
/*
Exception: Error
obj["@fn"]@Scratchpad/1:10:31
@Scratchpad/1:11:1
*/
```