### PR TITLE
Update stackframe to 1.0.2 and switch to the new API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ are given a `stack` once they're `throw`n.
 ErrorStackParser.parse(new Error('boom'));
 
 => [
-        StackFrame('funky1', [], 'path/to/file.js', 35, 79), 
-        StackFrame('filter', undefined, 'https://cdn.somewherefast.com/utils.min.js', 1, 832),
+        StackFrame({functionName: 'funky1', args: [], fileName: 'path/to/file.js', lineNumber: 35, columnNumber: 79}),
+        StackFrame({functionName: 'filter', fileName: 'https://cdn.somewherefast.com/utils.min.js', lineNumber: 1, columnNumber: 832}),
         StackFrame(... and so on ...)
    ]
 ```

--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -102,7 +102,13 @@
                 var functionName = tokens.join(' ') || undefined;
                 var fileName = _indexOf(['eval', '<anonymous>'], locationParts[0]) > -1 ? undefined : locationParts[0];
 
-                return new StackFrame(functionName, undefined, fileName, locationParts[1], locationParts[2], line);
+                return new StackFrame({
+                    functionName: functionName,
+                    fileName: fileName,
+                    lineNumber: locationParts[1],
+                    columnNumber: locationParts[2],
+                    source: line
+                });
             }, this);
         },
 
@@ -119,17 +125,21 @@
 
                 if (line.indexOf('@') === -1 && line.indexOf(':') === -1) {
                     // Safari eval frames only have function names and nothing else
-                    return new StackFrame(line);
+                    return new StackFrame({
+                        functionName: line
+                    });
                 } else {
                     var tokens = line.split('@');
                     var locationParts = this.extractLocation(tokens.pop());
                     var functionName = tokens.join('@') || undefined;
-                    return new StackFrame(functionName,
-                        undefined,
-                        locationParts[0],
-                        locationParts[1],
-                        locationParts[2],
-                        line);
+
+                    return new StackFrame({
+                        functionName: functionName,
+                        fileName: locationParts[0],
+                        lineNumber: locationParts[1],
+                        columnNumber: locationParts[2],
+                        source: line
+                    });
                 }
             }, this);
         },
@@ -153,7 +163,11 @@
             for (var i = 2, len = lines.length; i < len; i += 2) {
                 var match = lineRE.exec(lines[i]);
                 if (match) {
-                    result.push(new StackFrame(undefined, undefined, match[2], match[1], undefined, lines[i]));
+                    result.push(new StackFrame({
+                        fileName: match[2],
+                        lineNumber: match[1],
+                        source: lines[i]
+                    }));
                 }
             }
 
@@ -169,14 +183,12 @@
                 var match = lineRE.exec(lines[i]);
                 if (match) {
                     result.push(
-                        new StackFrame(
-                            match[3] || undefined,
-                            undefined,
-                            match[2],
-                            match[1],
-                            undefined,
-                            lines[i]
-                        )
+                        new StackFrame({
+                            functionName: match[3] || undefined,
+                            fileName: match[2],
+                            lineNumber: match[1],
+                            source: lines[i]
+                        })
                     );
                 }
             }
@@ -203,15 +215,16 @@
                 }
                 var args = (argsRaw === undefined || argsRaw === '[arguments not available]') ?
                     undefined : argsRaw.split(',');
-                return new StackFrame(
-                    functionName,
-                    args,
-                    locationParts[0],
-                    locationParts[1],
-                    locationParts[2],
-                    line);
+
+                return new StackFrame({
+                    functionName: functionName,
+                    args: args,
+                    fileName: locationParts[0],
+                    lineNumber: locationParts[1],
+                    columnNumber: locationParts[2],
+                    source: line
+                });
             }, this);
         }
     };
 }));
-

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "homepage": "https://www.stacktracejs.com",
   "dependencies": {
-    "stackframe": "^0.3.1"
+    "stackframe": "^1.0.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Update to the newest version of the stacktrace module and adapt to the backwards incompatible changes.

## Motivation and Context
error-stack-parser was stuck on an old pre-1.0.0 version of the stacktrace module. That caused some confusion for me as I had to use an old version of stacktrace in my app for things to work out.

## How Has This Been Tested?
The existing test suite passes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `node_modules/.bin/jscs -c .jscsrc error-stack-parser.js` passes without errors
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes