### PR TITLE
Fix typescript support

### DIFF
--- a/error-stack-parser.d.ts
+++ b/error-stack-parser.d.ts
@@ -62,3 +62,5 @@ declare module ErrorStackParser {
      */
     export function parse(error: Error): StackFrame[];
 }
+
+export = ErrorStackParser;

--- a/package.json
+++ b/package.json
@@ -53,10 +53,12 @@
     "url": "https://github.com/stacktracejs/error-stack-parser/issues"
   },
   "main": "./error-stack-parser.js",
+  "typings": "./error-stack-parser.d.ts",
   "files": [
     "LICENSE",
     "README.md",
     "error-stack-parser.js",
+    "error-stack-parser.d.ts",
     "dist/"
   ],
   "scripts": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A TypeScript definition is included in the source repository but it is not included in the published package (See #33). This pull request references the definition in the package.json so it is included in the package and it is no longer necessary to depend on the external `@types/error-stack-parser` package.

This PR also adds an export line into the definition so it is possible to import the library properly with ES6 syntax:

```typescript
import * as ErrorStackParser from "error-stack-parser";

const frames = ErrorStackParser.parse(new Error("Message"));
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `node_modules/.bin/jscs -c .jscsrc error-stack-parser.js` passes without errors
- [ ] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
