### PR TITLE
Fix typo in TypeScript definitions: TopLevel → Toplevel

### DIFF
--- a/error-stack-parser.d.ts
+++ b/error-stack-parser.d.ts
@@ -19,9 +19,9 @@ declare module ErrorStackParser {
         getIsNative(): boolean;
         setIsNative(): void;
 
-        isTopLevel?: boolean;
-        getIsTopLevel(): boolean;
-        setIsTopLevel(): void;
+        isToplevel?: boolean;
+        getIsToplevel(): boolean;
+        setIsToplevel(): void;
 
         columnNumber?: number;
         getColumnNumber(): number;


### PR DESCRIPTION
It would be better to import this type from `stackframe`, except the `stackframe` definitions don’t export anything (needs stacktracejs/stackframe#27). Feel free to fix it that way if you’re up for the extra release management work.