### PR TITLE
We seem to use `npm test`, not `gulp test`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Want to be listed as a *Contributor*? Make a pull request with:
 * Run `npm install` from the project directory
 
 ## Testing
-* (Local) Run `gulp test`. Make sure [Karma Local Config](karma.conf.js) has the browsers you want.
+* (Local) Run `npm test`. Make sure [Karma Local Config](karma.conf.js) has the browsers you want.
 * (Any browser, remotely) If you have a [Sauce Labs](https://saucelabs.com) account, you can run `gulp test-ci`.
  Make sure the target browser is enabled in [Karma CI Config](karma.conf.ci.js).
  Otherwise, Travis will run all browsers if you submit a Pull Request. 


### PR DESCRIPTION
## Description

Change contributing docs to use `npm test` not `gulp test`

## Motivation and Context

I wanted to contribute, and when I followed this step I got an error. Not even `npx gulp test` worked, and there's no gulpfile here, so I figured this step was out of date.

## Checklist:
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [x] I have updated the documentation accordingly
