### PR TITLE
fix: fixed parsing for node

### DIFF
--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -67,10 +67,10 @@
                 // remove the parenthesized location from the line, if it was matched
                 sanitizedLine = location ? sanitizedLine.replace(location[0], '') : sanitizedLine;
 
-                var tokens = sanitizedLine.split(/\s+/);
-                // if a location was matched, pass it to extractLocation() otherwise pop the last token
-                var locationParts = this.extractLocation(location ? location[1] : tokens.pop());
-                var functionName = tokens.join(' ') || undefined;
+                // if a location was matched, pass it to extractLocation() otherwise pass all sanitizedLine
+                // because this line doesn't have function name
+                var locationParts = this.extractLocation(location ? location[1] : sanitizedLine);
+                var functionName = location && sanitizedLine || undefined;
                 var fileName = ['eval', '<anonymous>'].indexOf(locationParts[0]) > -1 ? undefined : locationParts[0];
 
                 return new StackFrame({

--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -62,7 +62,7 @@
 
                 // capture and preseve the parenthesized location "(/foo/my bar.js:12:87)" in
                 // case it has spaces in it, as the string is split on \s+ later on
-                var location = sanitizedLine.match(/ (\((.+):(\d+):(\d+)\)$)/);
+                var location = sanitizedLine.match(/ (\(.+\)$)/);
 
                 // remove the parenthesized location from the line, if it was matched
                 sanitizedLine = location ? sanitizedLine.replace(location[0], '') : sanitizedLine;

--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -56,7 +56,7 @@
             return filtered.map(function(line) {
                 if (line.indexOf('(eval ') > -1) {
                     // Throw away eval information until we implement stacktrace.js/stackframe#8
-                    line = line.replace(/eval code/g, 'eval').replace(/(\(eval at [^()]*)|(\),.*$)/g, '');
+                    line = line.replace(/eval code/g, 'eval').replace(/(\(eval at [^()]*)|(,.*$)/g, '');
                 }
                 var sanitizedLine = line.replace(/^\s+/, '').replace(/\(eval code/g, '(').replace(/^.*?\s+/, '');
 

--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -58,7 +58,7 @@
                     // Throw away eval information until we implement stacktrace.js/stackframe#8
                     line = line.replace(/eval code/g, 'eval').replace(/(\(eval at [^()]*)|(\),.*$)/g, '');
                 }
-                var sanitizedLine = line.replace(/^\s+/, '').replace(/\(eval code/g, '(');
+                var sanitizedLine = line.replace(/^\s+/, '').replace(/\(eval code/g, '(').replace(/^.*?\s+/, '');
 
                 // capture and preseve the parenthesized location "(/foo/my bar.js:12:87)" in
                 // case it has spaces in it, as the string is split on \s+ later on
@@ -67,7 +67,7 @@
                 // remove the parenthesized location from the line, if it was matched
                 sanitizedLine = location ? sanitizedLine.replace(location[0], '') : sanitizedLine;
 
-                var tokens = sanitizedLine.split(/\s+/).slice(1);
+                var tokens = sanitizedLine.split(/\s+/);
                 // if a location was matched, pass it to extractLocation() otherwise pop the last token
                 var locationParts = this.extractLocation(location ? location[1] : tokens.pop());
                 var functionName = tokens.join(' ') || undefined;

--- a/spec/error-stack-parser-spec.js
+++ b/spec/error-stack-parser-spec.js
@@ -225,10 +225,13 @@ describe('ErrorStackParser', function() {
 
         it('should handle spaces in Node.js stacks', function() {
             var stackframes = unit.parse(CapturedExceptions.NODE_WITH_SPACES);
-            expect(stackframes.length).toBe(7);
+            expect(stackframes.length).toBe(8);
             expect(stackframes[0].fileName).toEqual('/var/app/scratch/my project/index.js');
             expect(stackframes[0].lineNumber).toBe(2);
             expect(stackframes[0].columnNumber).toBe(9);
+            expect(stackframes[1].fileName).toEqual('/var/app/scratch/my project/index.js');
+            expect(stackframes[1].lineNumber).toBe(2);
+            expect(stackframes[1].columnNumber).toBe(9);
         });
     });
 });

--- a/spec/fixtures/captured-errors.js
+++ b/spec/fixtures/captured-errors.js
@@ -387,7 +387,8 @@ CapturedExceptions.EDGE_20_NESTED_EVAL = {
 CapturedExceptions.NODE_WITH_SPACES = {
     name: 'Error',
     message: '',
-    stack: 'Error\n    at Object.<anonymous> ' +
+    stack: 'Error\n     at /var/app/scratch/my '+
+    'project/index.js:2:9\n    at Object.<anonymous> ' +
     '(/var/app/scratch/my ' +
     'project/index.js:2:9)\n    at Module._compile ' +
     '(internal/modules/cjs/loader.js:774:30)\n    at ' +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. added pre-replace unnecessary part of the line instead of slicing it after splitting
2. fixed removing last round bracket during throwing out eval information
3. removed regexp group ':(\d+):(\d+)' because we should get any location in brackets
4. removed splitting 'sanitizedLine' and reorganized using 'sanitizedLine' and 'location'
5. added a new option for node error test when the function name isn't there

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have a problem with the Node.js product. In some ways error looks like this:
```
Error
    at /var/app/scratch/my project/index.js:2:9
    at Object.<anonymous> (/var/app/scratch/my project/index.js:2:9)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11
```
First-line doesn't have a function name and round brackets and it loses full file name after splitting.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added new option for test 'should handle spaces in Node.js stacks'

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] `node_modules/.bin/jscs -c .jscsrc error-stack-parser.js` passes without errors
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
