### PR TITLE
Re-export StackFrame type for backwards compatibility

### DIFF
--- a/error-stack-parser.d.ts
+++ b/error-stack-parser.d.ts
@@ -6,6 +6,7 @@
 import StackFrame = require("stackframe");
 
 declare module ErrorStackParser {
+    export type {StackFrame};
     /**
      * Given an Error object, extract the most information from it.
      *


### PR DESCRIPTION
## Description

2.0.7 removed a mis-matching export of `StackFrame` (#54), but some users were relying on it. Re-export the correct one.

## Motivation and Context

https://github.com/stacktracejs/error-stack-parser/pull/54#commitcomment-66531802

## How Has This Been Tested?

`tsc error-stack-parser.d.ts`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] `node_modules/.bin/jscs -c .jscsrc error-stack-parser.js` passes without errors
  - (You removed `jscs` in f5184d7e89fcbdd54f06c4a8153010c0d1489ef5.)
- [x] `npm test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
  - (FYI, this is a broken link when you actually open a PR.)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
