### PR TITLE
Update types to reflect issue#45

### DIFF
--- a/error-stack-parser.d.ts
+++ b/error-stack-parser.d.ts
@@ -3,16 +3,16 @@
 // Definitions by: Eric Wendelin <https://www.eriwen.com>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import StackFrame = require("stackframe");
+import StackFrame from "stackframe";
 
-declare module ErrorStackParser {
+declare namespace ErrorStackParser {
     /**
      * Given an Error object, extract the most information from it.
      *
      * @param {Error} error object
      * @return {Array} of StackFrames
      */
-    export function parse(error: Error): StackFrame[];
+    function parse(error: Error): StackFrame[];
 }
 
-export = ErrorStackParser;
+export default ErrorStackParser;


### PR DESCRIPTION
The parse function should not be imported by itself. Types were updated accordingly.

## Description
The parse function should not be imported by itself, as explained in [issue#45](https://github.com/stacktracejs/error-stack-parser/issues/45). The issue arises because the types allow the parse function to be imported by itself, as a named export.
I changed the types so that the only possible import is the default export, like
`import ErrorStackParser from 'error-stack-parser';`
and the parse function can only be used like
`ErrorStackParser.parse(error)`

## Motivation and Context
This PR updates the types so that Issue #45 cannot occur, because the parse function cannot be imported by itself.

## How Has This Been Tested?
I tested the new types in a repo where I use error-stack-parser.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] `node_modules/.bin/jscs -c .jscsrc error-stack-parser.js` passes without errors
- [ ] `npm test` passes without errors
- [ ] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
