### PR TITLE
prevent parentheses in filenames being stripped out

### DIFF
--- a/error-stack-parser.js
+++ b/error-stack-parser.js
@@ -42,9 +42,10 @@
             if (urlLike.indexOf(':') === -1) {
                 return [urlLike];
             }
-
+            // strip any parentheses from start and end of string (but not from inside)
+            var withoutParens = urlLike.replace(/^\(+/, '').replace(/\)+$/, '');
             var regExp = /(.+?)(?::(\d+))?(?::(\d+))?$/;
-            var parts = regExp.exec(urlLike.replace(/[()]/g, ''));
+            var parts = regExp.exec(withoutParens);
             return [parts[1], parts[2] || undefined, parts[3] || undefined];
         },
 

--- a/spec/error-stack-parser-spec.js
+++ b/spec/error-stack-parser-spec.js
@@ -233,5 +233,13 @@ describe('ErrorStackParser', function() {
             expect(stackframes[1].lineNumber).toBe(2);
             expect(stackframes[1].columnNumber).toBe(9);
         });
+
+        it('should handle parentheses in filenames', function() {
+            var stackframes = unit.parse(CapturedExceptions.NODE_WITH_PARENTHESES);
+            expect(stackframes.length).toBe(7);
+            expect(stackframes[0].fileName).toEqual('/var/app/scratch/my project (top secret)/index.js');
+            expect(stackframes[0].lineNumber).toBe(2);
+            expect(stackframes[0].columnNumber).toBe(9);
+        });
     });
 });

--- a/spec/fixtures/captured-errors.js
+++ b/spec/fixtures/captured-errors.js
@@ -398,3 +398,17 @@ CapturedExceptions.NODE_WITH_SPACES = {
     'Function.Module.runMain (internal/modules/cjs/loader.js:837:10)\n    at ' +
     'internal/main/run_main_module.js:17:11'
 };
+
+CapturedExceptions.NODE_WITH_PARENTHESES = {
+    name: 'Error',
+    message: '',
+    stack: 'Error\n    at Object.<anonymous> ' +
+        '(/var/app/scratch/my ' +
+        'project (top secret)/index.js:2:9)\n    at Module._compile ' +
+        '(internal/modules/cjs/loader.js:774:30)\n    at ' +
+        'Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)\n   ' +
+        ' at Module.load (internal/modules/cjs/loader.js:641:32)\n    at ' +
+        'Function.Module._load (internal/modules/cjs/loader.js:556:12)\n    at ' +
+        'Function.Module.runMain (internal/modules/cjs/loader.js:837:10)\n    at ' +
+        'internal/main/run_main_module.js:17:11'
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Prevent parentheses in filenames from being incorrectly stripped out when parsing the raw stack frame.

This is done by changing `extractLocation`, which previously removed _all_ parens from its input, and now just strips them from the start and end (including multiple, which can happen with nested evals) which I think was probably the original intent.

## Motivation and Context
Fixes #62.

## How Has This Been Tested?
Added a test with an example stack (thanks to @mattwynne work in #61)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] `npm run lint` passes without errors
- [x] `npm run test` passes without errors
- [x] I have read the [contribution guidelines](CONTRIBUTING.md)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
