### PR TITLE
fix: use git+https:// repository URL instead of legacy git://

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/stacktracejs/error-stack-parser.git"
+    "url": "git+https://github.com/stacktracejs/error-stack-parser.git"
   },
   "devDependencies": {
     "eslint": "^8.17.0",


### PR DESCRIPTION
Changes `repository.url` from `git://` to `git+https://` to fix the deprecated git:// protocol.